### PR TITLE
Fix crash in map_fields and fix riemann_event for "%{field}" strings

### DIFF
--- a/lib/logstash/outputs/riemann.rb
+++ b/lib/logstash/outputs/riemann.rb
@@ -141,8 +141,8 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
     end
     if @map_fields == true
       @my_event = Hash.new
-      map_fields(nil, event)
-      r_event.merge!(@my_event) {|key, val1, val2| val1}
+      map_fields(nil, event.to_hash)
+      r_event.merge!(@my_event) {|key, val1, val2| event.sprintf(val1) }
     end
     r_event[:tags] = event["tags"] if event["tags"].is_a?(Array)
     @logger.debug("Riemann event: ", :riemann_event => r_event)


### PR DESCRIPTION
This is the same patch from PR #1, resubmitted by a user with
a signed CLA (me). Credit to @venturaville.
