### PR TITLE
Fixes #13 - Sender setting not honored

### DIFF
--- a/lib/logstash/outputs/riemann.rb
+++ b/lib/logstash/outputs/riemann.rb
@@ -109,7 +109,7 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
   def map_fields(parent, fields)
     this_level = Hash.new
     fields.each do |key, contents|
-      next if key.start_with?("@")
+      next if key.start_with?("@") or ["host","time","description"].include?(key)
       field = parent.nil? ? key : "#{parent}.#{key}"                         
       if contents.is_a?(Hash)                                     
         this_level.merge! map_fields(field, contents)                                       


### PR DESCRIPTION
The logic flow in `build_riemann_formatted_event` is incorrect if `map_fields => true`.
1. We set the `r_event[:host]` in https://github.com/logstash-plugins/logstash-output-riemann/blob/master/lib/logstash/outputs/riemann.rb#L136
2. If `map_fields` is enabled then it then maps all fields barring those starting with `@` in https://github.com/logstash-plugins/logstash-output-riemann/blob/master/lib/logstash/outputs/riemann.rb#L150.

Since `host` is a field in the event the mapping will override the previous setting.

This patch skips over mapping any of the fields: `host`, `time`, or `description` that we explictly set when building the event.
