### PR TITLE
update plugin api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
+jdk:
+ - oraclejdk8
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+ - jruby-1.7.25
+script:
+ - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-# 2.0.5
+## 3.0.0
+  - Breaking: Updated plugin to use new Java Event APIs
+  - relax logstash-core-plugin-api constrains
+  - update .travis.yml
+
+## 2.0.5
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.4
+
+## 2.0.4
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.3
  - Fix: when using `map_fields` with `sender` hostname would not be properly set
 
@@ -9,4 +16,3 @@
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/lib/logstash/outputs/riemann.rb
+++ b/lib/logstash/outputs/riemann.rb
@@ -122,8 +122,6 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
 
   public
   def receive(event)
-
-
     r_event = build_riemann_formatted_event(event)
 
     @logger.debug("Riemann event: ", :riemann_event => r_event)
@@ -134,7 +132,7 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
     # Let's build us an event, shall we?
     r_event = Hash.new
 
-    r_event[:description] = event["message"]
+    r_event[:description] = event.get("message")
 
     if @riemann_event
       @riemann_event.each do |key, val|
@@ -148,10 +146,10 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
     if @map_fields == true
       r_event.merge! map_fields(nil, event.to_hash)
     end
-    r_event[:tags] = event["tags"] if event["tags"].is_a?(Array)
+    r_event[:tags] = event.get("tags") if event.get("tags").is_a?(Array)
     r_event[:host] = event.sprintf(@sender)
     # riemann doesn't handle floats so we reduce the precision here
-    r_event[:time] = event["@timestamp"].to_i
+    r_event[:time] = event.timestamp.to_i
 
     return r_event
   end

--- a/logstash-output-riemann.gemspec
+++ b/logstash-output-riemann.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-output-riemann'
-  s.version         = '2.0.5'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Riemann is a network event stream processing system."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'riemann-client', ['0.2.1']
 


### PR DESCRIPTION
- Breaking: Updated plugin to use new Java Event APIs
- relax logstash-core-plugin-api constrains
- update .travis.yml
