### PR TITLE
fix fields override order

### DIFF
--- a/lib/logstash/outputs/riemann.rb
+++ b/lib/logstash/outputs/riemann.rb
@@ -134,6 +134,9 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
 
     r_event[:description] = event.get("message")
 
+    if @map_fields == true
+      r_event.merge! map_fields(nil, event.to_hash)
+    end
     if @riemann_event
       @riemann_event.each do |key, val|
         if ["ttl","metric"].include?(key)
@@ -142,9 +145,6 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
           r_event[key.to_sym] = event.sprintf(val)
         end
       end
-    end
-    if @map_fields == true
-      r_event.merge! map_fields(nil, event.to_hash)
     end
     r_event[:tags] = event.get("tags") if event.get("tags").is_a?(Array)
     r_event[:host] = event.sprintf(@sender)

--- a/spec/outputs/riemann_spec.rb
+++ b/spec/outputs/riemann_spec.rb
@@ -4,7 +4,7 @@ require "logstash/json"
 
 describe "outputs/riemann" do
   let(:output) { LogStash::Plugin.lookup("output", "riemann").new }
-  
+
   context "registration" do
 
     it "should register" do
@@ -130,5 +130,20 @@ describe "outputs/riemann" do
         expect(output.build_riemann_formatted_event(event)).to eq expected_data
       end
     end
+
+
+    context "with riemann_event and map_fields" do
+
+      let(:output) { LogStash::Plugin.lookup("output", "riemann").new("map_fields" => "true") }
+
+      it "will give precendence to fields in riemann_event" do
+        data = {"field_a" => "a_val1", "field_b" => "b_val1", "message" => "hello", "@version"=>"1", "@timestamp"=>"2015-06-03T23:34:54.076Z", "host"=>"vagrant-ubuntu-trusty-64"}
+        expected_data = {:time=>1433374494, :description =>"hello", :host =>"vagrant-ubuntu-trusty-64", :field_a => "a_val2", :field_b => "b_val1", :field_c => "c_val1", :message => "hello"}
+        event = LogStash::Event.new data
+        output.riemann_event = {"field_a" => "a_val2", "field_c" => "c_val1"}
+        expect(output.build_riemann_formatted_event(event)).to eq expected_data
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The current documentation of `map_fields` is inconsistent with the actual implementation.
The event currently takes precedence over fields in `riemann_event`.
This PR fixes that and adds a unit test to verify this behaviour
