### PR TITLE
upgrade riemann-client to 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.0.7
-  - Updated riemann-client gem to 0.2.6 to benefit timeout support
+  - Updated riemann-client gem to 0.2.6 to benefit timeout support [#26](https://github.com/logstash-plugins/logstash-output-riemann/pull/26)
 
 ## 3.0.6
   - Fix values from "riemann_event" not overwriting those from "map_fields".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.7
+  - Updated riemann-client gem to 0.2.6 to benefit timeout support
+
 ## 3.0.6
   - Fix values from "riemann_event" not overwriting those from "map_fields".
     [#22](https://github.com/logstash-plugins/logstash-output-riemann/issues/22)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ reports, or in general have helped logstash along its way.
 Contributors:
 * Aaron Mildenstein (untergeek)
 * Cameron Stokes (clstokes)
+* Colin Surprenant (colinsurprenant)
 * John E. Vincent (lusis)
 * Jonas Tehler (jegt)
 * Jordan Sissel (jordansissel)

--- a/logstash-output-riemann.gemspec
+++ b/logstash-output-riemann.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-riemann'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends metrics to Riemann"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency 'riemann-client', ['0.2.1']
+  s.add_runtime_dependency 'riemann-client', "~> 0.2.6"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency "logstash-codec-plain"

--- a/spec/outputs/riemann_spec.rb
+++ b/spec/outputs/riemann_spec.rb
@@ -16,7 +16,7 @@ describe "outputs/riemann" do
         expect {
           output = LogStash::Plugin.lookup("output", "riemann").new("protocol" => "fake")
           output.register
-          }.to raise_error
+          }.to raise_error(LogStash::ConfigurationError)
       end
 
       it "should not error out if set to [tcp]" do


### PR DESCRIPTION
Fixes #25 
upgrade riemann-client to 0.2.6 to benefit timeout support
improved a spec
bumped versions to 3.0.7

